### PR TITLE
Added optional tapering to HRF_calc with custom start time, end time,…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: hrf
 Title: Hemodynamic Response Function
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
     person(given = "Amanda",
            family = "Mejia",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: hrf
 Title: Hemodynamic Response Function
-Version: 0.1.3
+Version: 0.2.0
 Authors@R: c(
     person(given = "Amanda",
            family = "Mejia",

--- a/R/HRF_calc.R
+++ b/R/HRF_calc.R
@@ -62,9 +62,6 @@ HRF_calc <- function(t, deriv=0, a1=6, b1=1, a2=16/6 * a1 * sqrt(b1), b2=b1, c=1
     h <- (fplus - fminus)/(2*delta)
   }
 
-  # Drop first value, which equals zero.
-  h <- h[-1]
-
   h
 }
 

--- a/R/HRF_calc.R
+++ b/R/HRF_calc.R
@@ -79,9 +79,6 @@ HRF_calc <- function(t, deriv=0, a1=6, b1=1, a2=16/6 * a1 * sqrt(b1), b2=b1, c=1
     h <- cosine_taper(h, t, taper_start, taper_end, taper_power)
   }
 
-  # Drop first value, which equals zero.
-  h <- h[-1]
-
   h
 }
 
@@ -293,6 +290,7 @@ cderiv <- function(x){
 #' @param taper_end time (in seconds) to fully decay to zero
 #' @param taper_power exponent to shape the taper curve (P=1 is cosine arc)
 #'
+#' @keywords internal
 #' @return tapered HRF vector
 cosine_taper <- function(h, t, taper_start, taper_end = 30, taper_power = 1) {
   taper <- rep(1, length(h))


### PR DESCRIPTION
### Summary
- Updated HRF_calc to support cosine tapering using new parameters:
  - `taper_start`: time to begin taper (no default; taper only applied if specified)
  - `taper_end`: time to reach zero (default = 30s)
  - `taper_power`: controls sharpness of taper curve (default = 1)

- Added warnings:
  - If `c = 0` but tapering is requested
  - If `taper_start > taper_end`
  - If `taper_start` is after the time vector ends
  - If `taper_start` is before the HRF peak (may affect peak)

- Modularized cosine tapering into a helper function `cosine_taper`.

### Motivation
- Needed more flexible and explicit control over when and how HRFs are tapered.
- Allow user to specify taper timing manually instead of auto-detecting peak.
- Improve clarity and robustness with better warnings.

### Testing
- Verified correct behavior with multiple time resolutions.
- Plotted HRFs before and after tapering across different parameters (`a1`, `b1`, `c`).